### PR TITLE
Allow Github to render the article link

### DIFF
--- a/pages/DEV.md
+++ b/pages/DEV.md
@@ -30,7 +30,7 @@
 	- [Erc721 vs Erc721a Batch minting nfts](https://www.alchemy.com//blog/erc721-vs-erc721a-batch-minting-nfts)
 	- [NFT drop with revenue share](https://blog.thirdweb.com/guides/nft-drop-with-revenue-share/)
 - #Code
-	- [From Junior to Genius: an optimization story]([https://itnext.io/from-junior-to-genius-an-optimization-story-ab20afc8159d](https://itnext.io/from-junior-to-genius-an-optimization-story-ab20afc8159d))
+	- [From Junior to Genius: an optimization story](https://itnext.io/from-junior-to-genius-an-optimization-story-ab20afc8159d)
 	- #Playground [Scroll Indicator](https://play.tailwindcss.com/cB8FNN70zd)
 - #Curiosities
 	- [Fourier Interactive Drawing](https://www.jezzamon.com/fourier/index.html)


### PR DESCRIPTION
The error was caused by extra characters.